### PR TITLE
Caddyfile storage section is part of global parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,27 @@ This plugin currently work with versions of Caddy v2, for the previous version o
 ## Configuration
 You enable Redis storage with Caddy by setting the storage module used, for example
 ```
-//all value is optional, here is the default
-storage redis {
-  host          "127.0.0.1"
-  port          6379
-  address       "127.0.0.1:6379" // no default, but is build from host+":"+port, if set, then host and port is ignored
-  password      ""
-  db            1
-  key_prefix    "caddytls"
-  value_prefix  "caddy-storage-redis"
-  timeout       5
-  tls_enabled   "false"
-  tls_insecure  "true"
-  aes_key       "redistls-01234567890-caddytls-32" // optional, but must have 32 length
+{
+	//all value is optional, here is the default
+	storage redis {
+	  host          "127.0.0.1"
+	  port          6379
+	  address       "127.0.0.1:6379" // no default, but is build from host+":"+port, if set, then host and port is ignored
+	  password      ""
+	  db            1
+	  key_prefix    "caddytls"
+	  value_prefix  "caddy-storage-redis"
+	  timeout       5
+	  tls_enabled   "false"
+	  tls_insecure  "true"
+	  aes_key       "redistls-01234567890-caddytls-32" // optional, but must have 32 length
+	}
+	// because the option are set using env, there are no need for additional option value
 }
-// because the option are set using env, there are no need for additional option value
+
+:443 {
+
+}
 ```
 
 JSON example


### PR DESCRIPTION
I first tried copying in the config into my Caddyfile directly which didn't work. [The docs of the consul plugin](https://github.com/pteich/caddy-tlsconsul#caddy-configuration) make it more clear where the config is supposed to go. This PR applies a similar format