### PR TITLE
Redact set password and add test to verify

### DIFF
--- a/storageredis.go
+++ b/storageredis.go
@@ -633,6 +633,9 @@ var (
 )
 
 func (rd RedisStorage) String() string {
+	if rd.Password != "" {
+		rd.Password = "REDACTED"
+	}
 	strVal, _ := json.Marshal(rd)
 	return string(strVal)
 }

--- a/storageredis.go
+++ b/storageredis.go
@@ -633,8 +633,12 @@ var (
 )
 
 func (rd RedisStorage) String() string {
+	redacted := `REDACTED`
 	if rd.Password != "" {
-		rd.Password = "REDACTED"
+		rd.Password = redacted
+	}
+	if rd.AesKey != "" {
+		rd.AesKey = redacted
 	}
 	strVal, _ := json.Marshal(rd)
 	return string(strVal)

--- a/storageredis_test.go
+++ b/storageredis_test.go
@@ -2,6 +2,7 @@ package storageredis
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path"
 	"sync"
@@ -210,4 +211,25 @@ func TestRedisStorage_MultipleLocks(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestRedisStorage_String(t *testing.T) {
+	rd := new(RedisStorage)
+	t.Run("validate password", func(t *testing.T) {
+		t.Run("is redacted when set", func(t *testing.T) {
+			testrd := new(RedisStorage)
+			password := "iAmASuperSecurePassword"
+			rd.Password = password
+			err := json.Unmarshal([]byte(rd.String()), &testrd)
+			assert.NoError(t, err)
+			assert.Equal(t, "REDACTED", testrd.Password)
+			assert.Equal(t, password, rd.Password)
+		})
+		rd.Password = ""
+		t.Run("is empty if not set", func(t *testing.T) {
+			err := json.Unmarshal([]byte(rd.String()), &rd)
+			assert.NoError(t, err)
+			assert.Empty(t, rd.Password)
+		})
+	})
 }

--- a/storageredis_test.go
+++ b/storageredis_test.go
@@ -215,6 +215,7 @@ func TestRedisStorage_MultipleLocks(t *testing.T) {
 
 func TestRedisStorage_String(t *testing.T) {
 	rd := new(RedisStorage)
+	redacted := `REDACTED`
 	t.Run("validate password", func(t *testing.T) {
 		t.Run("is redacted when set", func(t *testing.T) {
 			testrd := new(RedisStorage)
@@ -222,7 +223,7 @@ func TestRedisStorage_String(t *testing.T) {
 			rd.Password = password
 			err := json.Unmarshal([]byte(rd.String()), &testrd)
 			assert.NoError(t, err)
-			assert.Equal(t, "REDACTED", testrd.Password)
+			assert.Equal(t, redacted, testrd.Password)
 			assert.Equal(t, password, rd.Password)
 		})
 		rd.Password = ""
@@ -230,6 +231,23 @@ func TestRedisStorage_String(t *testing.T) {
 			err := json.Unmarshal([]byte(rd.String()), &rd)
 			assert.NoError(t, err)
 			assert.Empty(t, rd.Password)
+		})
+	})
+	t.Run("validate AES key", func(t *testing.T) {
+		t.Run("is redacted when set", func(t *testing.T) {
+			testrd := new(RedisStorage)
+			aeskey := "abcdefghijklmnopqrstuvwxyz123456"
+			rd.AesKey = aeskey
+			err := json.Unmarshal([]byte(rd.String()), &testrd)
+			assert.NoError(t, err)
+			assert.Equal(t, redacted, testrd.AesKey)
+			assert.Equal(t, aeskey, rd.AesKey)
+		})
+		rd.AesKey = ""
+		t.Run("is empty if not set", func(t *testing.T) {
+			err := json.Unmarshal([]byte(rd.String()), &rd)
+			assert.NoError(t, err)
+			assert.Empty(t, rd.AesKey)
 		})
 	})
 }


### PR DESCRIPTION
Greetings,

In standing up the Redis Storage Module for Caddy, it was noticed that logging was printing out the password in the clear:

```json
{
  "level": "info",
  "ts": 1626799330.1127865,
  "logger": "tls",
  "msg": "cleaning storage unit",
  "description": "{\"Client\":{},\"ClientLocker\":{},\"Logger\":{},\"address\":\"192.168.1.1:6378\",\"host\":\"192.168.1.1\",\"port\":\"6378\",\"db\":0,\"username\":\"\",\"password\":\"IDontThinkIShouldBeHere\",\"timeout\":5,\"key_prefix\":\"caddytls\",\"value_prefix\":\"caddy-storage-redis\",\"aes_key\":\"\",\"tls_enabled\":true,\"tls_insecure\":false}"
}
```

This pull request will redact the password if it is set. Additionally, included some tests to validate this is working.