### PR TITLE
Replace usage of certmagic.ErrNotExist

### DIFF
--- a/storageredis.go
+++ b/storageredis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -479,7 +480,9 @@ func (rd RedisStorage) Stat(_ context.Context, key string) (certmagic.KeyInfo, e
 func (rd RedisStorage) getData(key string) ([]byte, error) {
 	data, err := rd.Client.Get(rd.ctx, rd.prefixKey(key)).Bytes()
 
-	if err != nil {
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, fs.ErrNotExist
+	} else if err != nil {
 		return nil, fmt.Errorf("unable to obtain data for %s: %v", key, err)
 	} else if data == nil {
 		return nil, fs.ErrNotExist

--- a/storageredis.go
+++ b/storageredis.go
@@ -480,7 +480,7 @@ func (rd RedisStorage) Stat(_ context.Context, key string) (certmagic.KeyInfo, e
 func (rd RedisStorage) getData(key string) ([]byte, error) {
 	data, err := rd.Client.Get(rd.ctx, rd.prefixKey(key)).Bytes()
 
-	if errors.Is(err, fs.ErrNotExist) {
+	if errors.Is(err, redis.Nil) {
 		return nil, fs.ErrNotExist
 	} else if err != nil {
 		return nil, fmt.Errorf("unable to obtain data for %s: %v", key, err)

--- a/storageredis_test.go
+++ b/storageredis_test.go
@@ -3,12 +3,13 @@ package storageredis
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path"
 	"sync"
 	"testing"
 
-	"github.com/caddyserver/certmagic"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,8 +91,8 @@ func TestRedisStorage_Delete(t *testing.T) {
 	contentLoaded, err := rd.Load(key)
 	assert.Nil(t, contentLoaded)
 
-	_, ok := err.(certmagic.ErrNotExist)
-	assert.True(t, ok)
+	notExist := errors.Is(err, fs.ErrNotExist)
+	assert.True(t, notExist)
 }
 
 func TestRedisStorage_Stat(t *testing.T) {


### PR DESCRIPTION
This PR replaces the usage of `certmagic.ErrNotExist` with `fs.ErrNotExist`.

Resolves #36.