### PR TITLE
Caddy storage export command always results in an empty tar

### DIFF
--- a/storageredis.go
+++ b/storageredis.go
@@ -488,7 +488,7 @@ func (rd RedisStorage) Stat(_ context.Context, key string) (certmagic.KeyInfo, e
 		Key:        key,
 		Modified:   data.Modified,
 		Size:       int64(len(data.Value)),
-		IsTerminal: false,
+		IsTerminal: true,
 	}, nil
 }
 


### PR DESCRIPTION
I am able to replicate [issue #46](https://github.com/gamalan/caddy-tlsredis/issues/46) reported by @jum, it appears when the `caddy storage export` command iterates over the keys, it expects `KeyInfo.IsTerminal` returned by `Stat()` to be `true`  in order to include in the exported tar file:

https://github.com/caddyserver/caddy/blob/4e8245df0b289007e84f42212977ea0bd27826d5/cmd/storagefuncs.go#L196

This makes sense since each key returned by `List()` in this Redis storage implementation is a data object and not a directory object.  Unfortunately `KeyInfo.IsTerminal` is currently hard-coded to `false` and thus no keys are included in the export:

https://github.com/gamalan/caddy-tlsredis/blob/1d90bd3f80cb3c600e4c756d431cfb831f6a1c10/storageredis.go#L491

This PR simply changes the hard-coded value of `KeyInfo.IsTerminal` from `false` to `true` when then allows all keys stored in Redis to be exported correctly.

CC: @francislavoie 