### PR TITLE
Avoid references to rd.Port and rd.Host until after they are initialized.

### DIFF
--- a/storageredis.go
+++ b/storageredis.go
@@ -293,7 +293,7 @@ func (rd *RedisStorage) ReplaceEnvConfigCaddy() {
 	rd.KeyPrefix = repl.ReplaceAll(rd.KeyPrefix, DefaultKeyPrefix)
 	rd.ValuePrefix = repl.ReplaceAll(rd.ValuePrefix, DefaultValuePrefix)
 	rd.AesKey = repl.ReplaceAll(rd.AesKey, DefaultAESKey)
-	rd.Address = configureString(repl.ReplaceAll(rd.Address, ""), "", rd.Host+":"+rd.Port)
+	rd.Address = configureString(repl.ReplaceAll(rd.Address, ""), "", "")
 	rd.logger.Debugf("GetConfigValue [%s]:%s", "post", rd)
 }
 


### PR DESCRIPTION
This is kind of a bandaid fix, the real solution would be to merge GetConfigValue and ReplaceEnvConfigCaddy into one function and sort the references to the variables according to the order how they are referenced.